### PR TITLE
Fix type error in sendPing example code (string to bytes conversion)

### DIFF
--- a/docs/pages/integrate-concero/send-a-message.mdx
+++ b/docs/pages/integrate-concero/send-a-message.mdx
@@ -45,7 +45,7 @@ contract ConceroQuickStartSender {
             validatorConfigs: validatorConfigs,
             relayerLib: relayerLib,                // per-message relayer selection
             relayerConfig: relayerConfig,
-            payload: text
+            payload: bytes(text)
         });
 
         // 3) Quote total fee (relayer + validators), then send


### PR DESCRIPTION
I ran the `sendPing` example code from the documentation locally and encountered a compilation error. The `MessageRequest` struct expects the `payload` field to be of type `bytes`, but the example currently passes `text` (which is a `string`) directly without casting.

Error

```
Invalid type for argument in function call. Invalid implicit conversion from string calldata to bytes memory requested.
```

The Fix: I have updated the line to explicitly cast the string to bytes:

```
- payload: text
+ payload: bytes(text)
```

This resolves the error and ensures the example compiles correctly for users copying it into their projects.